### PR TITLE
Use Docker Compose to pull and run a prebuilt container image from Docker Hub

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,30 +1,7 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.231.5/containers/docker-existing-dockerfile
 {
-	"name": "Golioth Zephyr Dockerfile",
-	// Sets the run context to one level up instead of the .devcontainer folder.
-	"context": "..",
-	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-	"dockerFile": "../Dockerfile",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [],
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	"build": {
-		"args": {
-			"ZEPHYR_VERSION": "main",
-			"ARCHITECTURE": "x86_64",
-			"ZEPHYR_SDK_VERSION": "0.14.2",
-			"TOOLCHAIN": "arm-zephyr-eabi"
-		}
-	}
-	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	"name": "Golioth Zephyr Docker Compose file",
+	"dockerComposeFile": "../docker-compose.yml",
+	"service": "west",
+	"workspaceFolder": "/root",
+	"shutdownAction": "stopCompose"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS common 
+FROM debian:stable-slim AS common
 
 RUN \
   apt-get -y update \
@@ -40,4 +40,3 @@ RUN \
   file wget xz-utils \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,28 @@
-FROM debian:stable-slim AS common
-
-ARG ZEPHYR_VERSION=v3.2.0
-ENV ZEPHYR_VERSION=${ZEPHYR_VERSION}
+FROM debian:stable-slim AS common 
 
 RUN \
   apt-get -y update \
   && apt-get -y install --no-install-recommends \
   device-tree-compiler \
   git \
+  ninja-build \
   python3 \
   python3-pip \
-  python3-wheel \
+  python3-venv \
   && pip3 install cmake \
-  && pip3 install west \
-  && pip3 install \
-  -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/${ZEPHYR_VERSION}/scripts/requirements-base.txt \
   && apt-get remove -y --purge \
   python3-pip \
-  python3-wheel \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /root/Desktop/Downloads
 
 FROM common AS toolchain
 
 ARG ARCHITECTURE=x86_64
 ARG ZEPHYR_SDK_VERSION=0.15.1
 ARG ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
+
+WORKDIR /root
 
 RUN \
   export sdk_file_name="zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-$(uname -m)_minimal.tar.gz" \
@@ -43,3 +40,4 @@ RUN \
   file wget xz-utils \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Develop Golioth applications with Zephyr on macOS using Docker Desktop. No other
   * [Install](#install)
   * [Develop](#develop)
 
-Container image releases of this project are available on [Docker Hub](https://hub.docker.com/repository/docker/st8l3ss/zephyr-sdk-x86_64/general).
+Prebuilt container image releases of this project are available on [Docker Hub](https://hub.docker.com/repository/docker/st8l3ss/zephyr-sdk-x86_64/general).
 
 ## Build
 
@@ -24,8 +24,8 @@ This command builds an x86_64 container image for version 0.15.2 of the Zephyr S
 
 Both build arguments are optional:
 
-* ARCHITECTURE - CPU architecture for the Docker container. Not to be confused with the target architecture for Zephyr.
-* ZEPHYR_SDK_VERSION - SDK version. Must be 0.14.1 or later.
+* **ARCHITECTURE** - CPU architecture for the Docker container. Not to be confused with the target architecture for Zephyr.
+* **ZEPHYR_SDK_VERSION** - SDK version. Must be 0.14.1 or later.
 
 If either build argument is missing from the command line the build defaults to the value defined inside the `Dodkerfile`.
 
@@ -43,13 +43,7 @@ cd golioth-zephyr-docker
 docker compose up -d
 ```
 
-A container named `golioth` should now appear as "Running" in Docker Desktop.
-
-To open a terminal inside the running container:
-
-```
-docker exec -it golioth /bin/bash
-```
+After some time, a container named `golioth` should now appear as "Running" in Docker Desktop.
 
 Alternatively, the `west` service can be started from within VS Code as a Dev Container:
 
@@ -59,14 +53,79 @@ Alternatively, the `west` service can be started from within VS Code as a Dev Co
 3. Select *Command Palette ...* from the *View* menu.
 5. Enter *Dev Containers: Reopen in Container* in the Command Palette.
 
-Once a connection with the Dev Container has been established you can open a *New Terminal* inside the running container from within VS Code.
+Once a connection with the Dev Container has been established, you can open a *New Terminal* inside the running container from within VS Code.
 
 ## Develop
 
-The `projects` directory is mounted as `/root` inside the container. This way you can execute Git commands and use VS Code to edit source code on your host machine.
-
-All project builds are done inside the container as `root` using Python virtual environments. The binary artifacts are then bundled and saved to your `Downloads` directory on your host machine for flashing like so:
+To open a terminal inside the running container:
 
 ```
+docker exec -it golioth /bin/bash
+```
+
+The `projects` directory you created in your home directory is mounted as `/root` inside the container. This way you can execute Git commands and use VS Code to edit source code on your host machine.
+
+All project builds are done inside the container as `root` using Python virtual environments. To build Golioth's magtag-demo, follow the instructions in the [README](https://github.com/golioth/magtag-demo).
+
+To create a dedicated Python virtual environment for the magtag-demo:
+
+``` bash
+cd ~
+mkdir magtag-demo
+python3 -m venv magtag-demo/.venv
+source magtag-demo/.venv/bin/activate
+pip install wheel
+pip install west
+pip install esptool
+```
+
+To clone the golioth/magtag-demo repository and install Zephyr along with all necessary modules:
+
+``` bash
+cd ~
+west init -m https://github.com/golioth/magtag-demo.git magtag-demo
+cd magtag-demo
+west update
+west zephyr-export
+pip install -r ~/magtag-demo/deps/zephyr/scripts/requirements.txt
+west blobs fetch hal_espressif
+```
+
+**Note**: When using a Python virtual environment, remember to re-enable it with each new terminal session:
+
+``` bash
+source ~/magtag-demo/.venv/bin/activate
+```
+
+Add a `credentials.conf` file and populate the various fields as shown in the [Golioth Developer Training](https://training.golioth.io/docs/golioth-exercises/compile-golioth-demo).
+
+To build the magtag-demo:
+
+``` bash
+cd ~/magtag-demo/app
+west build -b esp32s2_saola golioth-demo -p
+```
+
+Once the build is finished, the binary artifacts can be bundled and saved to the `Downloads` folder on your host machine  like so:
+
+``` bash
+cd ~/magtag-demo/app
 west kasm download
 ```
+
+To flash the MagTag with your build bundle, first install `esptool.py` on your host machine:
+
+``` bash
+pip3 install esptool
+```
+
+Then flash the last build bundle saved to your `Downloads` folder:
+
+``` bash
+cd ~/Downloads
+esptool.py --chip esp32s2 --port /dev/tty.usbmodem01 write_flash 0x0 merged_<appfolder>_<hhmmss>.bin
+```
+
+Replace `<appfolder>` and `<hhmmss>` with the actual values from the most recent magtag-demo build bundle in your `Downloads` folder.
+
+**Note**: The USB-A to Micro USB cable I used to flash my MagTag appeared as `/dev/tty.usbmodem01` on my MacBook Pro. Your cable may be different.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To build this project, make sure you have Git and Docker installed on your host 
 Clone the repo and buikd a release of the container image:
 
 ``` shell
-git clone https://github.com/fvasquez/golioth-zephyr-docker .
+git clone https://github.com/beriberikix/golioth-zephyr-docker .
 cd golioth-zephyr-docker
 docker build --build-arg ARCHITECTURE=x86_64 --build-arg ZEPHYR_SDK_VERSION=0.15.2 -t zephyr-sdk-x86_64:v15.2 .
 ```
@@ -38,7 +38,7 @@ Before running the container image, create a `projects` directory inside your ho
 Clone the repo and start the `west` service:
 
 ``` shell
-git clone https://github.com/fvasquez/golioth-zephyr-docker .
+git clone https://github.com/beriberikix/golioth-zephyr-docker .
 cd golioth-zephyr-docker
 docker compose up -d
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  west:
+    image: st8l3ss/zephyr-sdk-x86_64:latest
+    container_name: golioth
+    volumes:
+      - ~/projects:/root
+      - ~/Downloads:/root/Desktop/Downloads
+    entrypoint:
+      - bash
+    tty: true
+    stdin_open: true
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,3 @@ services:
       - bash
     tty: true
     stdin_open: true
-


### PR DESCRIPTION
Both west and Zephyr are now installed in Python virtual environments on the container. The idea is not to use `docker run` to run west but to run west in a terminal inside the container.

- Removed west and Zephyr installation from the `Dockerfile`.
- Added a `docker-compose.yml` file that pulls my `zephyr-sdk-x86_64:latest` image from Docker Hub.
- Integrated this `docker-compose.yml` file into the `devcontainer.json` file for VS Code.
- Rewrote the `README.md` to target Docker Desktop on macOS.

TODO: I need to verify GitHub Actions can still publish an image to ghcr.io and put the Dev Container badge back on the README for CI.
